### PR TITLE
Remove webview wildcard from default values

### DIFF
--- a/charts/theia-cloud/Chart.yaml
+++ b/charts/theia-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0-next.1
+version: 0.12.0-next.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud/values.yaml
+++ b/charts/theia-cloud/values.yaml
@@ -84,7 +84,8 @@ hosts:
   # IMPORTANT: If this gets updated, the helm chart needs to be re-installed because
   # helm upgrade will not properly update this at the moment.
   # These are required to configure TLS (if enabled via ingress.tls == true)
-  allWildcardInstances: ["*.webview."]
+  # I.e. custom certificates or a cert-manager provider that can handle wildcard certificates need to be configured.
+  allWildcardInstances: []
 
 # -- Values related to the landing page
 # @default -- (see details below)


### PR DESCRIPTION
The webview wildcard configuration breaks default deployments because it requires additional configuration to generate/use wildcard certificates. This is not supported by Let's encrypt out of the box.

Thus, remove the webview wildcard configuration from the default values.

Related to #71 