### PR TITLE
Extend operator and service K8S permissions for eager start handling

### DIFF
--- a/charts/theia-cloud-base/Chart.yaml
+++ b/charts/theia-cloud-base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0-next.0
+version: 1.1.0-next.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud-base/templates/operator-role.yaml
+++ b/charts/theia-cloud-base/templates/operator-role.yaml
@@ -25,4 +25,5 @@ rules:
       - configmaps
       - deployments
       - leases
-    verbs: ["list", "create", "watch", "get", "patch", "delete", "update"]
+      - pods
+    verbs: ["list", "create", "watch", "get", "edit", "patch", "delete", "update"]

--- a/charts/theia-cloud-base/templates/service-role.yaml
+++ b/charts/theia-cloud-base/templates/service-role.yaml
@@ -16,7 +16,10 @@ rules:
     verbs: ["list", "create", "watch", "get", "patch", "delete"]
   - apiGroups:
       - ""
+      - apps
       - metrics.k8s.io
     resources:
+      - deployments
+      - replicasets
       - pods
     verbs: ["list", "get", "watch"]


### PR DESCRIPTION
### Allow operator to edit pods to add annotations for eager start

This is necessary to update the OAuth proxy config map in time

### Allow service to read Deployments and ReplicaSets to trace owner refs 

Read access to Deployments and ReplicaSets allows the service to trace owner references from Pods over ReplicaSets and Deployments to  the Pod's Session.
This is required to find a Pod's corresponding Session (and vice-versa) in eager start mode. This is necessary because the Pod's ENV cannot contain the session name in eager start mode.