### PR TITLE
Add admin group configuration for the service deployment

### DIFF
--- a/charts/theia-cloud/Chart.yaml
+++ b/charts/theia-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0-next.0
+version: 1.1.0-next.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud/README.md
+++ b/charts/theia-cloud/README.md
@@ -1,6 +1,6 @@
 # theia-cloud
 
-![Version: 1.1.0-next.0](https://img.shields.io/badge/Version-1.1.0--next.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0-next](https://img.shields.io/badge/AppVersion-1.1.0--next-informational?style=flat-square)
+![Version: 1.1.0-next.1](https://img.shields.io/badge/Version-1.1.0--next.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0-next](https://img.shields.io/badge/AppVersion-1.1.0--next-informational?style=flat-square)
 
 A Helm chart for Theia Cloud
 
@@ -45,6 +45,7 @@ A Helm chart for Theia Cloud
 | issuer | object | (see details below) | Values related to certificates/Cert-manager |
 | issuer.email | string | `"mmorlock@example.com"` | EMail address of the certificate issuer. |
 | keycloak | object | (see details below) | Values related to Keycloak |
+| keycloak.adminGroup | string | `"theia-cloud/admin"` | The name of the Keycloak group identifying admin users who are allowed to access the service's admin endpoints. |
 | keycloak.authUrl | string | `"https://keycloak.url/auth/"` | Key cloak auth URL. Only has to be specified when enable: true |
 | keycloak.clientId | string | `"theia-cloud"` | The client-id. Only has to be specified when enable: true |
 | keycloak.clientSecret | string | `"publicbutoauth2proxywantsasecret"` | The oaid client secret. In case you configure your keycloak client as confidential, then you may specifiy the secret here. If you stick with our default public client, you may leave below value. For public clients keycloak does not generate a client-secret, but in order to make oath2-proxy happy, we will pass a value |

--- a/charts/theia-cloud/templates/service-configmap.yaml
+++ b/charts/theia-cloud/templates/service-configmap.yaml
@@ -8,6 +8,7 @@ data:
   SERVICE_PORT: {{ tpl (.Values.service.port | toString) . | quote }}
   KEYCLOAK_ENABLE: {{ tpl (.Values.keycloak.enable | toString) . | quote }}
   {{- if eq (tpl (.Values.keycloak.enable | toString) .) "true" }}
+  KEYCLOAK_ADMIN_GROUP: {{ tpl (.Values.keycloak.adminGroup | toString) . }}
   KEYCLOAK_SERVERURL: {{ tpl (.Values.keycloak.authUrl | toString) . }}realms/{{ tpl (.Values.keycloak.realm | toString) . }}
   KEYCLOAK_CLIENTID: {{ tpl (.Values.keycloak.clientId | toString) . }}
   KEYCLOAK_CLIENTSECRET: {{ tpl (.Values.keycloak.clientSecret | toString) . }}

--- a/charts/theia-cloud/values.yaml
+++ b/charts/theia-cloud/values.yaml
@@ -158,6 +158,9 @@ keycloak:
   # -- Whether keycloak authentication shall be used
   enable: false
 
+  # -- The name of the Keycloak group identifying admin users who are allowed to access the service's admin endpoints.
+  adminGroup: "theia-cloud/admin"
+
   # -- Key cloak auth URL. Only has to be specified when enable: true
   authUrl: "https://keycloak.url/auth/"
 


### PR DESCRIPTION
Add value `keycloak.adminGroup` to the theia-cloud chart to allow customizing the group name identifying admin users.