### PR TITLE
theia-cloud: Make OAuth2 Proxy's allowed redirect domains configurable

### DIFF
--- a/charts/theia-cloud/Chart.yaml
+++ b/charts/theia-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0-next.0
+version: 1.1.0-next.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/theia-cloud/templates/oauth2-configmap-oauth2proxy-keycloak.yaml
+++ b/charts/theia-cloud/templates/oauth2-configmap-oauth2proxy-keycloak.yaml
@@ -32,11 +32,29 @@ data:
     skip_provider_button="true"
     reverse_proxy="true"
     # email_domains=["*"]
+    {{- $cookieDomains := .Values.oauth2Proxy.cookieDomains | default (list) }}
+    {{- $whitelistDomains := .Values.oauth2Proxy.whitelistDomains | default (list) }}
     {{- if .Values.hosts.usePaths }}
+      {{- if gt (len $cookieDomains) 0 }}
+    cookie_domains={{ toJson $cookieDomains }}
+      {{- else }}
     cookie_domains=["{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}"]
-    whitelist_domains=["{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}:*","{{ $keycloakHost }}:*",".google.com:*"]
+      {{- end }}
+      {{- if gt (len $whitelistDomains) 0 }}
+    whitelist_domains={{ toJson $whitelistDomains }}
+      {{- else }}
+    whitelist_domains=["{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}:*","{{ $keycloakHost }}:*"]
+      {{- end }}
     {{- else }}
+      {{- if gt (len $cookieDomains) 0 }}
+    cookie_domains={{ toJson $cookieDomains }}
+      {{- else }}
     cookie_domains=["{{ tpl (.Values.hosts.configuration.instance | toString) . }}.{{ tpl (.Values.hosts.configuration.baseHost | toString) . }}"]
-    whitelist_domains=["{{ tpl (.Values.hosts.configuration.instance | toString) . }}:*","{{ $keycloakHost }}:*",".google.com:*"]
+      {{- end }}
+      {{- if gt (len $whitelistDomains) 0 }}
+    whitelist_domains={{ toJson $whitelistDomains }}
+      {{- else }}
+    whitelist_domains=["{{ tpl (.Values.hosts.configuration.instance | toString) . }}:*","{{ $keycloakHost }}:*"]
+      {{- end }}
     {{- end }}
     custom_templates_dir="/templates"

--- a/charts/theia-cloud/values.yaml
+++ b/charts/theia-cloud/values.yaml
@@ -179,6 +179,20 @@ keycloak:
   # for how to generate a strong cookie secret.
   cookieSecret: "OQINaROshtE9TcZkNAm5Zs2Pv3xaWytBmc5W7sPX7ws="
 
+# -- Values related to OAuth2 Proxy configuration
+oauth2Proxy:
+  # Allowed redirect domains for OAuth2 Proxy (controls whitelist_domains).
+  # When empty, defaults are used:
+  #   if hosts.usePaths: [ "<baseHost>:*", "<keycloak host>:*" ]
+  #   else: [ "<instance>:*", "<keycloak host>:*" ]
+  whitelistDomains: []
+
+  # Cookie domains for OAuth2 Proxy.
+  # When empty, defaults are used:
+  #   if hosts.usePaths: [ "<baseHost>" ]
+  #   else: [ "<instance>.<baseHost>" ]
+  cookieDomains: []
+
 # -- Values related to the operator
 # @default -- (see details below)
 operator:


### PR DESCRIPTION
- Make whitelist_domains and cookie_domains configurable
- Default is the previous behaviour: landing page and session host
- Removes google.com from the default allowed redirects because there is no indication that this is necessary

Fixes eclipse-theia/theia-cloud#357